### PR TITLE
feat(region): add ability to specify region as an arg or get from env

### DIFF
--- a/src/args.ts
+++ b/src/args.ts
@@ -10,6 +10,7 @@ type Args = {
   'stack-name': string
   'identity-store-id': string
   'managing-instance-arn': string
+  region: string
   verbose: boolean
   help: boolean
 }

--- a/src/args.ts
+++ b/src/args.ts
@@ -34,6 +34,12 @@ const optionsConfig = {
     default: '',
     help: 'Pass the arn of the managing instance. If not provided will try to fetch for an existing one',
   },
+  region: {
+    type: 'string',
+    short: 'r',
+    default: '',
+    help: 'Pass the region to be used. If not provided will use the value of the AWS_REGION environment variable.',
+  },
   verbose: {
     type: 'boolean',
     short: 'v',

--- a/src/index.ts
+++ b/src/index.ts
@@ -44,7 +44,18 @@ await getOrgFormationVersion($$)
 // 1. determine identity store id and managing instance arn
 let identityStoreId = args['identity-store-id']
 let managingInstanceArn = args['managing-instance-arn']
+let region = args.region
 const stackName = args['stack-name']
+if (!region) {
+  // biome-ignore lint/nursery/noProcessEnv: <explanation>
+  region = process.env.AWS_REGION as string
+  if (!region) {
+    console.error(
+      'please set AWS_REGION environment variable or provide region as an argument'
+    )
+    process.exit(1)
+  }
+}
 if (!(identityStoreId && managingInstanceArn)) {
   console.warn(
     'identity-store-id or managing-instance-arn not provided, trying to determine them...'
@@ -58,6 +69,7 @@ if (!(identityStoreId && managingInstanceArn)) {
   }
   identityStoreId = ssoInstances[0]?.IdentityStoreId as string
   managingInstanceArn = ssoInstances[0]?.InstanceArn as string
+  console.warn(`region: ${region}`)
   console.warn(`identity-store-id: ${identityStoreId}`)
   console.warn(`managing-instance-arn: ${managingInstanceArn}`)
 }
@@ -79,6 +91,7 @@ console.info(`✅ Created ${TEMP_DIR}/organization-tasks.yml`)
 const baseTemplateContent = createBaseOrgFormationSsoAssignmentsYml({
   identityStoreId,
   managingInstanceArn,
+  region,
 })
 await writeFile(`${TEMP_DIR}/sso-assignments.yml`, baseTemplateContent)
 console.info(`✅ Created ${TEMP_DIR}/sso-assignments.yml`)
@@ -174,6 +187,7 @@ console.info('✅ Created organization-tasks.yml')
 const finalSsoAssignmentsContent = createOrgFormationSsoAssignmentsYml({
   identityStoreId,
   managingInstanceArn,
+  region,
   accounts,
   groups,
   permissionSets,

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -340,15 +340,18 @@ export function createOrganizationTasksYml({
 export function createBaseOrgFormationSsoAssignmentsYml({
   identityStoreId,
   managingInstanceArn,
+  region,
 }: {
   identityStoreId: string
   managingInstanceArn: string
+  region: string
 }) {
   const baseTemplateContent = nunjucksEnv.render(
     'sso-assignments-base.yml.njk',
     {
       identityStoreId,
       managingInstanceArn,
+      region,
       groups: [
         {
           name: TEMP_GROUP_NAME,
@@ -368,11 +371,13 @@ type CreateOrgFormationSsoAssignmentsYmlOptions = {
   permissionSets: ExtendedPermissionSet[]
   assignments: AccountAssignment[]
   accounts: OrgFormationAccount[]
+  region: string
 }
 
 export function createOrgFormationSsoAssignmentsYml({
   identityStoreId,
   managingInstanceArn,
+  region,
   groups,
   permissionSets,
   assignments,
@@ -385,6 +390,7 @@ export function createOrgFormationSsoAssignmentsYml({
   const templateContent = nunjucksEnv.render('sso-assignments.yml.njk', {
     identityStoreId,
     managingInstanceArn,
+    region,
     groups,
     permissionSets,
     assignments,

--- a/templates/sso-assignments-base.yml.njk
+++ b/templates/sso-assignments-base.yml.njk
@@ -9,7 +9,7 @@ OrganizationBindings:
     IncludeMasterAccount: true
 
 DefaultOrganizationBinding: !Ref ManagementAccountBinding
-DefaultOrganizationBindingRegion: eu-west-1
+DefaultOrganizationBindingRegion: {{ region }}
 
 Parameters:
   IdentityStoreId:

--- a/templates/sso-assignments.yml.njk
+++ b/templates/sso-assignments.yml.njk
@@ -9,7 +9,7 @@ OrganizationBindings:
     IncludeMasterAccount: true
 
 DefaultOrganizationBinding: !Ref ManagementAccountBinding
-DefaultOrganizationBindingRegion: eu-west-1
+DefaultOrganizationBindingRegion: {{ region }}
 
 Parameters:
   IdentityStoreId:


### PR DESCRIPTION
In index.ts added a check for the region as an arg. If not present, fallback to getting the region from the AWS_REGION environment variable, and throw an error if neither is found.

Amended two templates to use the region variable.

This adds the ability to execute this script in regions other than eu-west-1, which was hardcoded in two of the templates.